### PR TITLE
Add Ellipse and Rhombus figures to hw_02_figures

### DIFF
--- a/hw_02_figures/src/Ellipse.py
+++ b/hw_02_figures/src/Ellipse.py
@@ -1,0 +1,81 @@
+from math import pi, sqrt
+
+from ..src.Figure import Figure
+
+
+class Ellipse(Figure):
+    name = "Ellipse"
+
+    def __init__(self, semi_major_axis, semi_minor_axis):
+        if not all(
+            isinstance(axis, (int, float))
+            for axis in [semi_major_axis, semi_minor_axis]
+        ):
+            raise TypeError("Semi-axes should be numeric")
+        if semi_major_axis < 0 or semi_minor_axis < 0:
+            raise ValueError("Semi-axes should be >= 0")
+        self._semi_major_axis = semi_major_axis
+        self._semi_minor_axis = semi_minor_axis
+
+    @property
+    def semi_major_axis(self):
+        return self._semi_major_axis
+
+    @property
+    def semi_minor_axis(self):
+        return self._semi_minor_axis
+
+    @property
+    def area(self):
+        return pi * self.semi_major_axis * self.semi_minor_axis
+
+    @property
+    def perimeter(self):
+        a = self.semi_major_axis
+        b = self.semi_minor_axis
+        return pi * (3 * (a + b) - sqrt((3 * a + b) * (a + 3 * b)))
+
+    def __str__(self):
+        return (
+            f"{self.name}(semi_major_axis={self.semi_major_axis}, "
+            f"semi_minor_axis={self.semi_minor_axis})"
+        )
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __eq__(self, other):
+        if not isinstance(other, Ellipse):
+            return False
+        return (
+            self.semi_major_axis == other.semi_major_axis
+            and self.semi_minor_axis == other.semi_minor_axis
+        )
+
+    def __hash__(self):
+        return hash((self.semi_major_axis, self.semi_minor_axis))
+
+    def __lt__(self, other):
+        if not isinstance(other, Ellipse):
+            raise TypeError("Cannot compare Ellipse with non-Ellipse object")
+        return self.area < other.area
+
+    def __gt__(self, other):
+        if not isinstance(other, Ellipse):
+            raise TypeError("Cannot compare Ellipse with non-Ellipse object")
+        return self.area > other.area
+
+    def __le__(self, other):
+        if not isinstance(other, Ellipse):
+            raise TypeError("Cannot compare Ellipse with non-Ellipse object")
+        return self.area <= other.area
+
+    def __ge__(self, other):
+        if not isinstance(other, Ellipse):
+            raise TypeError("Cannot compare Ellipse with non-Ellipse object")
+        return self.area >= other.area
+
+    def add_area(self, figure):
+        if not hasattr(figure, "area"):
+            raise ValueError(f"Cannot add area of {figure} - it's not a valid figure")
+        return self.area + figure.area

--- a/hw_02_figures/src/Rhombus.py
+++ b/hw_02_figures/src/Rhombus.py
@@ -1,0 +1,83 @@
+from math import sqrt
+
+from ..src.Figure import Figure
+
+
+class Rhombus(Figure):
+    name = "Rhombus"
+
+    def __init__(self, diagonal_a, diagonal_b):
+        if not all(
+            isinstance(diagonal, (int, float))
+            for diagonal in [diagonal_a, diagonal_b]
+        ):
+            raise TypeError("Diagonals should be numeric")
+        if diagonal_a <= 0 or diagonal_b <= 0:
+            raise ValueError("Rhombus diagonals should be > 0")
+        self._diagonal_a = diagonal_a
+        self._diagonal_b = diagonal_b
+
+    @property
+    def diagonal_a(self):
+        return self._diagonal_a
+
+    @property
+    def diagonal_b(self):
+        return self._diagonal_b
+
+    @property
+    def side(self):
+        return sqrt((self.diagonal_a / 2) ** 2 + (self.diagonal_b / 2) ** 2)
+
+    @property
+    def area(self):
+        return self.diagonal_a * self.diagonal_b / 2
+
+    @property
+    def perimeter(self):
+        return 4 * self.side
+
+    def __str__(self):
+        return (
+            f"{self.name}(diagonal_a={self.diagonal_a}, "
+            f"diagonal_b={self.diagonal_b})"
+        )
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __eq__(self, other):
+        if not isinstance(other, Rhombus):
+            return False
+        return (
+            self.diagonal_a == other.diagonal_a
+            and self.diagonal_b == other.diagonal_b
+        )
+
+    def __hash__(self):
+        return hash((self.diagonal_a, self.diagonal_b))
+
+    def __lt__(self, other):
+        if not isinstance(other, Rhombus):
+            raise TypeError("Cannot compare Rhombus with non-Rhombus object")
+        return self.area < other.area
+
+    def __gt__(self, other):
+        if not isinstance(other, Rhombus):
+            raise TypeError("Cannot compare Rhombus with non-Rhombus object")
+        return self.area > other.area
+
+    def __le__(self, other):
+        if not isinstance(other, Rhombus):
+            raise TypeError("Cannot compare Rhombus with non-Rhombus object")
+        return self.area <= other.area
+
+    def __ge__(self, other):
+        if not isinstance(other, Rhombus):
+            raise TypeError("Cannot compare Rhombus with non-Rhombus object")
+        return self.area >= other.area
+
+    def add_area(self, figure):
+        if not hasattr(figure, "area"):
+            raise ValueError(f"Cannot add area of {figure} - it's not a valid figure")
+        return self.area + figure.area

--- a/hw_02_figures/tests/test_ellipse.py
+++ b/hw_02_figures/tests/test_ellipse.py
@@ -1,0 +1,141 @@
+from math import pi, sqrt
+
+import pytest
+
+from ..src.Circle import Circle
+from ..src.Ellipse import Ellipse
+from ..src.Figure import Figure
+from ..src.Rectangle import Rectangle
+
+
+@pytest.mark.parametrize(
+    "semi_major_axis, semi_minor_axis, expected_area",
+    [
+        (0, 5, 0),
+        (5, 0, 0),
+        (3, 4, 12 * pi),
+        (2.5, 2, 5 * pi),
+    ],
+)
+def test_ellipse_area(semi_major_axis, semi_minor_axis, expected_area):
+    ellipse = Ellipse(semi_major_axis, semi_minor_axis)
+    assert ellipse.area == pytest.approx(expected_area)
+    assert isinstance(ellipse.area, (int, float))
+
+
+def test_ellipse_perimeter():
+    ellipse = Ellipse(3, 4)
+    expected = pi * (3 * (3 + 4) - sqrt((3 * 3 + 4) * (3 + 3 * 4)))
+    assert ellipse.perimeter == pytest.approx(expected)
+
+
+def test_ellipse_has_name():
+    assert Ellipse(1, 2).name == "Ellipse"
+
+
+def test_ellipse_is_figure_instance():
+    assert isinstance(Ellipse(2, 3), Figure)
+
+
+@pytest.mark.parametrize("semi_major_axis, semi_minor_axis", [("aaa", 1), (1, None), (2, "*&^")])
+def test_create_ellipse_with_invalid_axes(semi_major_axis, semi_minor_axis):
+    with pytest.raises(TypeError, match="Semi-axes should be numeric"):
+        Ellipse(semi_major_axis, semi_minor_axis)
+
+
+@pytest.mark.parametrize(
+    "semi_major_axis, semi_minor_axis",
+    [(-1, 2), (2, -1), (-3, -4)],
+)
+def test_create_ellipse_with_negative_axes(semi_major_axis, semi_minor_axis):
+    with pytest.raises(ValueError, match="Semi-axes should be >= 0"):
+        Ellipse(semi_major_axis, semi_minor_axis)
+
+
+def test_ellipse_add_area_with_ellipse():
+    ellipse1 = Ellipse(3, 4)
+    ellipse2 = Ellipse(2, 5)
+    assert ellipse1.add_area(ellipse2) == pytest.approx(ellipse1.area + ellipse2.area)
+
+
+def test_ellipse_add_area_with_different_figure(create_rectangle):
+    ellipse = Ellipse(3, 4)
+    assert ellipse.add_area(create_rectangle) == pytest.approx(ellipse.area + create_rectangle.area)
+
+
+def test_ellipse_matches_circle_when_axes_are_equal():
+    radius = 5
+    ellipse = Ellipse(radius, radius)
+    circle = Circle(radius)
+
+    assert ellipse.area == pytest.approx(circle.area)
+    assert ellipse.perimeter == pytest.approx(circle.perimeter)
+
+
+def test_ellipse_equality():
+    ellipse1 = Ellipse(3, 4)
+    ellipse2 = Ellipse(3, 4)
+    ellipse3 = Ellipse(4, 3)
+
+    assert ellipse1 == ellipse2
+    assert ellipse1 != ellipse3
+    assert ellipse1 != Circle(3)
+
+
+def test_ellipse_hash():
+    ellipse1 = Ellipse(3, 4)
+    ellipse2 = Ellipse(3, 4)
+    ellipse3 = Ellipse(4, 3)
+
+    assert hash(ellipse1) == hash(ellipse2)
+    assert hash(ellipse1) != hash(ellipse3)
+
+
+def test_ellipse_comparison_operators():
+    smaller = Ellipse(2, 3)
+    larger = Ellipse(4, 5)
+    equal = Ellipse(2, 3)
+
+    assert smaller < larger
+    assert larger > smaller
+    assert smaller <= equal
+    assert smaller <= larger
+    assert larger >= smaller
+    assert smaller >= equal
+
+
+def test_ellipse_ordering_rejects_non_ellipses():
+    ellipse = Ellipse(2, 3)
+
+    with pytest.raises(TypeError, match="Cannot compare Ellipse with non-Ellipse object"):
+        ellipse < Circle(2)
+
+
+def test_ellipse_add_area_with_invalid_argument():
+    ellipse = Ellipse(3, 4)
+
+    with pytest.raises(ValueError, match="Cannot add area of"):
+        ellipse.add_area("not a figure")
+
+
+def test_ellipse_str_and_repr():
+    ellipse = Ellipse(3, 4.5)
+    expected = "Ellipse(semi_major_axis=3, semi_minor_axis=4.5)"
+    assert str(ellipse) == expected
+    assert repr(ellipse) == expected
+
+
+def test_ellipse_properties_are_immutable():
+    ellipse = Ellipse(3, 4)
+
+    with pytest.raises(AttributeError):
+        ellipse.semi_major_axis = 10
+    with pytest.raises(AttributeError):
+        ellipse.semi_minor_axis = 10
+
+
+def test_ellipse_add_area_with_rectangle():
+    ellipse = Ellipse(2, 3)
+    rectangle = Rectangle(4, 5)
+
+    assert ellipse.add_area(rectangle) == pytest.approx(ellipse.area + rectangle.area)

--- a/hw_02_figures/tests/test_rhombus.py
+++ b/hw_02_figures/tests/test_rhombus.py
@@ -1,0 +1,154 @@
+from math import sqrt
+
+import pytest
+
+from ..src.Circle import Circle
+from ..src.Ellipse import Ellipse
+from ..src.Figure import Figure
+from ..src.Rectangle import Rectangle
+from ..src.Rhombus import Rhombus
+from ..src.Square import Square
+
+
+@pytest.mark.parametrize(
+    "diagonal_a, diagonal_b, expected_area",
+    [
+        (6, 8, 24),
+        (4, 4, 8),
+        (2.5, 4, 5),
+    ],
+)
+def test_rhombus_area(diagonal_a, diagonal_b, expected_area):
+    rhombus = Rhombus(diagonal_a, diagonal_b)
+    assert rhombus.area == pytest.approx(expected_area)
+    assert isinstance(rhombus.area, (int, float))
+
+
+@pytest.mark.parametrize(
+    "diagonal_a, diagonal_b, expected_perimeter",
+    [
+        (6, 8, 20),
+        (4, 4, 4 * sqrt(8)),
+    ],
+)
+def test_rhombus_perimeter(diagonal_a, diagonal_b, expected_perimeter):
+    rhombus = Rhombus(diagonal_a, diagonal_b)
+    assert rhombus.perimeter == pytest.approx(expected_perimeter)
+
+
+def test_rhombus_side():
+    rhombus = Rhombus(6, 8)
+    assert rhombus.side == pytest.approx(5)
+
+
+def test_rhombus_has_name():
+    assert Rhombus(3, 4).name == "Rhombus"
+
+
+def test_rhombus_is_figure_instance():
+    assert isinstance(Rhombus(3, 4), Figure)
+
+
+@pytest.mark.parametrize("diagonal_a, diagonal_b", [("aaa", 4), (3, None), (2, "*&^")])
+def test_create_rhombus_with_invalid_diagonals(diagonal_a, diagonal_b):
+    with pytest.raises(TypeError, match="Diagonals should be numeric"):
+        Rhombus(diagonal_a, diagonal_b)
+
+
+@pytest.mark.parametrize(
+    "diagonal_a, diagonal_b",
+    [(0, 4), (3, 0), (-2, 5), (4, -1)],
+)
+def test_create_rhombus_with_non_positive_diagonals(diagonal_a, diagonal_b):
+    with pytest.raises(ValueError, match="Rhombus diagonals should be > 0"):
+        Rhombus(diagonal_a, diagonal_b)
+
+
+def test_rhombus_add_area_with_rhombus():
+    rhombus1 = Rhombus(6, 8)
+    rhombus2 = Rhombus(4, 4)
+    assert rhombus1.add_area(rhombus2) == pytest.approx(rhombus1.area + rhombus2.area)
+
+
+def test_rhombus_add_area_with_different_figure(create_rectangle):
+    rhombus = Rhombus(6, 8)
+    assert rhombus.add_area(create_rectangle) == pytest.approx(rhombus.area + create_rectangle.area)
+
+
+def test_rhombus_matches_square_when_diagonals_form_square():
+    side = 4
+    diagonal = side * sqrt(2)
+    rhombus = Rhombus(diagonal, diagonal)
+    square = Square(side)
+
+    assert rhombus.area == pytest.approx(square.area)
+    assert rhombus.perimeter == pytest.approx(square.perimeter)
+
+
+def test_rhombus_equality():
+    rhombus1 = Rhombus(6, 8)
+    rhombus2 = Rhombus(6, 8)
+    rhombus3 = Rhombus(8, 6)
+
+    assert rhombus1 == rhombus2
+    assert rhombus1 != rhombus3
+    assert rhombus1 != Square(4)
+
+
+def test_rhombus_hash():
+    rhombus1 = Rhombus(6, 8)
+    rhombus2 = Rhombus(6, 8)
+    rhombus3 = Rhombus(8, 6)
+
+    assert hash(rhombus1) == hash(rhombus2)
+    assert hash(rhombus1) != hash(rhombus3)
+
+
+def test_rhombus_comparison_operators():
+    smaller = Rhombus(4, 4)
+    larger = Rhombus(6, 8)
+    equal = Rhombus(4, 4)
+
+    assert smaller < larger
+    assert larger > smaller
+    assert smaller <= equal
+    assert smaller <= larger
+    assert larger >= smaller
+    assert smaller >= equal
+
+
+def test_rhombus_ordering_rejects_non_rhombuses():
+    rhombus = Rhombus(6, 8)
+
+    with pytest.raises(TypeError, match="Cannot compare Rhombus with non-Rhombus object"):
+        rhombus < Ellipse(2, 3)
+
+
+def test_rhombus_add_area_with_invalid_argument():
+    rhombus = Rhombus(6, 8)
+
+    with pytest.raises(ValueError, match="Cannot add area of"):
+        rhombus.add_area("not a figure")
+
+
+def test_rhombus_str_and_repr():
+    rhombus = Rhombus(6, 8.5)
+    expected = "Rhombus(diagonal_a=6, diagonal_b=8.5)"
+    assert str(rhombus) == expected
+    assert repr(rhombus) == expected
+
+
+def test_rhombus_properties_are_immutable():
+    rhombus = Rhombus(6, 8)
+
+    with pytest.raises(AttributeError):
+        rhombus.diagonal_a = 10
+    with pytest.raises(AttributeError):
+        rhombus.diagonal_b = 10
+
+
+def test_rhombus_add_area_with_circle():
+    rhombus = Rhombus(6, 8)
+    circle = Circle(2)
+
+    assert rhombus.add_area(circle) == pytest.approx(rhombus.area + circle.area)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends `hw_02_figures` with two new figure types, demonstrating that the `Figure` base class supports adding shapes beyond the original four.

- **`Ellipse`** — semi-major and semi-minor axes, with area (`πab`), perimeter (Ramanujan approximation), equality, ordering, and `add_area` support
- **`Rhombus`** — diagonal-based rhombus with area (`d₁d₂/2`), perimeter from side length, equality, ordering, and `add_area` support
- **50 new tests** covering validation, equivalence with existing figures (circle/square), and cross-figure area sums

## Test plan

- [x] `python3 -m pytest hw_02_figures/tests/ -q` — 168 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1501-9e06-7561-a587-df43f991fa30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1501-9e06-7561-a587-df43f991fa30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

